### PR TITLE
Corrected namespaces for Query and ODMQuery.

### DIFF
--- a/en/reference/map-reduce-queries.rst
+++ b/en/reference/map-reduce-queries.rst
@@ -78,7 +78,7 @@ Both queries have a common base class with a simple API:
 
     <?php
 
-    namespace Doctrine\ODM\CouchDB\View;
+    namespace Doctrine\CouchDB\View;
 
     abstract class AbstractQuery
     {
@@ -114,9 +114,7 @@ The following query parameter related methods exist in both the native and odm-q
 .. code-block:: php
 
     <?php
-    namespace Doctrine\ODM\CouchDB\View;
-
-    use Doctrine\ODM\CouchDB\DocumentManager;
+    namespace Doctrine\CouchDB\View;
 
     class Query extends AbstractQuery
     {


### PR DESCRIPTION
```
$ find . -name *Query.php*
./lib/Doctrine/ODM/CouchDB/View/ODMQuery.php
./lib/Doctrine/ODM/CouchDB/View/ODMLuceneQuery.php
./lib/Doctrine/CouchDB/View/LuceneQuery.php
./lib/Doctrine/CouchDB/View/Query.php
./lib/Doctrine/CouchDB/View/AbstractQuery.php
```
