### PR TITLE
doc.doctrine_metadata.type has been moved to doc.type in alpha2

### DIFF
--- a/en/reference/map-reduce-queries.rst
+++ b/en/reference/map-reduce-queries.rst
@@ -41,7 +41,7 @@ the username map.js might look like:
 .. code-block:: javascript
 
     function(doc) {
-        if (doc.doctrine_metadata.type == 'Doctrine.Tests.Models.CMS.CmsUser') {
+        if (doc.type == 'Doctrine.Tests.Models.CMS.CmsUser') {
             emit(doc.username, doc._id);
         }
     }


### PR DESCRIPTION
No further information required.
