### PR TITLE
fix syntax highlighting

### DIFF
--- a/en/reference/attachments.rst
+++ b/en/reference/attachments.rst
@@ -24,6 +24,7 @@ The API of the ``Doctrine\CouchDB\Attachment`` looks as follows:
 
 .. code-block:: php
 
+    <?php
     namespace Doctrine\CouchDB;
 
     class Attachment


### PR DESCRIPTION
fix syntax highlighting for class Doctrine\CouchDB\Attachment
